### PR TITLE
Add consolidated document entity

### DIFF
--- a/src/main/java/com/code4ro/legalconsultation/model/persistence/Article.java
+++ b/src/main/java/com/code4ro/legalconsultation/model/persistence/Article.java
@@ -2,9 +2,11 @@ package com.code4ro.legalconsultation.model.persistence;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.Table;
 import java.math.BigInteger;
 
 @Entity
+@Table(name = "articles")
 public class Article extends BaseEntity {
 
     @Column(name = "article_number", unique=true, nullable=false)

--- a/src/main/java/com/code4ro/legalconsultation/model/persistence/Chapter.java
+++ b/src/main/java/com/code4ro/legalconsultation/model/persistence/Chapter.java
@@ -1,13 +1,12 @@
 package com.code4ro.legalconsultation.model.persistence;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.OneToMany;
+import javax.persistence.*;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.List;
 
 @Entity
+@Table(name = "chapters")
 public class Chapter extends BaseEntity {
 
     @Column(name = "chapter_number",unique=true, nullable=false)
@@ -16,7 +15,8 @@ public class Chapter extends BaseEntity {
     @Column(name = "chapter_title", nullable=false)
     private String chapterTitle;
 
-    @OneToMany
+    @OneToMany(fetch = FetchType.EAGER)
+    @JoinColumn(name = "article_id", referencedColumnName = "id")
     private List<Article> articles = new ArrayList<>();
 
     public BigInteger getChapterNumber() {

--- a/src/main/java/com/code4ro/legalconsultation/model/persistence/DocumentBreakdown.java
+++ b/src/main/java/com/code4ro/legalconsultation/model/persistence/DocumentBreakdown.java
@@ -1,39 +1,16 @@
 package com.code4ro.legalconsultation.model.persistence;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.OneToMany;
-import java.math.BigInteger;
+import javax.persistence.*;
 import java.util.ArrayList;
 import java.util.List;
 
 @Entity
+@Table(name = "document_chapters")
 public class DocumentBreakdown extends BaseEntity {
 
-    @Column(name = "document_number", unique=true, nullable=false)
-    private BigInteger documentNumber;
-
-    @Column(name = "document_title", nullable=false)
-    private String documentTitle;
-
     @OneToMany
+    @JoinColumn(name = "chapter_id", referencedColumnName = "id")
     private List<Chapter> chapters = new ArrayList<>();
-
-    public BigInteger getDocumentNumber() {
-        return documentNumber;
-    }
-
-    public void setDocumentNumber(BigInteger documentNumber) {
-        this.documentNumber = documentNumber;
-    }
-
-    public String getDocumentTitle() {
-        return documentTitle;
-    }
-
-    public void setDocumentTitle(String documentTitle) {
-        this.documentTitle = documentTitle;
-    }
 
     public List<Chapter> getChapters() {
         return chapters;

--- a/src/main/java/com/code4ro/legalconsultation/model/persistence/DocumentConsolidated.java
+++ b/src/main/java/com/code4ro/legalconsultation/model/persistence/DocumentConsolidated.java
@@ -1,0 +1,40 @@
+package com.code4ro.legalconsultation.model.persistence;
+
+import javax.persistence.*;
+
+@Entity
+@Table(name = "consolidated_document")
+public class DocumentConsolidated extends BaseEntity {
+
+    @OneToOne(fetch = FetchType.EAGER, optional = false)
+    @JoinColumn(name = "metadata_id", referencedColumnName = "id")
+    private DocumentMetadata documentMetadata;
+
+    @OneToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "breakdown_id", referencedColumnName = "id")
+    private DocumentBreakdown documentBreakdown;
+
+    public DocumentConsolidated(DocumentMetadata documentMetadata, DocumentBreakdown documentBreakdown) {
+        this.documentMetadata = documentMetadata;
+        this.documentBreakdown = documentBreakdown;
+    }
+
+    public DocumentConsolidated() {
+    }
+
+    public DocumentMetadata getDocumentMetadata() {
+        return documentMetadata;
+    }
+
+    public void setDocumentMetadata(DocumentMetadata documentMetadata) {
+        this.documentMetadata = documentMetadata;
+    }
+
+    public DocumentBreakdown getDocumentBreakdown() {
+        return documentBreakdown;
+    }
+
+    public void setDocumentBreakdown(DocumentBreakdown documentBreakdown) {
+        this.documentBreakdown = documentBreakdown;
+    }
+}

--- a/src/main/java/com/code4ro/legalconsultation/model/persistence/DocumentMetadata.java
+++ b/src/main/java/com/code4ro/legalconsultation/model/persistence/DocumentMetadata.java
@@ -5,6 +5,7 @@ import java.math.BigInteger;
 import java.util.Date;
 
 @Entity
+@Table(name = "document_description")
 public class DocumentMetadata extends BaseEntity {
 
     @Column(name = "document_number", unique=true, nullable=false)

--- a/src/main/java/com/code4ro/legalconsultation/repository/DocumentConsolidatedRepository.java
+++ b/src/main/java/com/code4ro/legalconsultation/repository/DocumentConsolidatedRepository.java
@@ -1,0 +1,11 @@
+package com.code4ro.legalconsultation.repository;
+
+import com.code4ro.legalconsultation.model.persistence.DocumentConsolidated;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.UUID;
+
+@Repository
+public interface DocumentConsolidatedRepository extends JpaRepository<DocumentConsolidated, UUID> {
+}

--- a/src/main/java/com/code4ro/legalconsultation/service/impl/DocumentConsolidatedService.java
+++ b/src/main/java/com/code4ro/legalconsultation/service/impl/DocumentConsolidatedService.java
@@ -1,0 +1,45 @@
+package com.code4ro.legalconsultation.service.impl;
+
+import com.code4ro.legalconsultation.model.persistence.DocumentConsolidated;
+import com.code4ro.legalconsultation.repository.DocumentConsolidatedRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Service
+public class DocumentConsolidatedService {
+
+    private static final Logger logger = LoggerFactory.getLogger(DocumentConsolidatedService.class);
+
+    private final DocumentConsolidatedRepository documentConsolidatedRepository;
+
+    @Autowired
+    public DocumentConsolidatedService(final DocumentConsolidatedRepository repository){
+        this.documentConsolidatedRepository = repository;
+    }
+
+    public Optional<DocumentConsolidated> findOne(final String uuid){
+        return documentConsolidatedRepository.findById(UUID.fromString(uuid));
+    }
+
+    public List<DocumentConsolidated> findAll(){
+        return documentConsolidatedRepository.findAll();
+    }
+
+    public DocumentConsolidated saveOne(final DocumentConsolidated documentConsolidated){
+        return documentConsolidatedRepository.save(documentConsolidated);
+    }
+
+    public List<DocumentConsolidated> saveAll(List<DocumentConsolidated> documentConsolidatedList){
+        return documentConsolidatedRepository.saveAll(documentConsolidatedList);
+    }
+
+    public void deleteById(final String uuid){
+        documentConsolidatedRepository.deleteById(UUID.fromString(uuid));
+    }
+}


### PR DESCRIPTION
Add consolidated document as part of the entity model, to link document metadata entity and document breakdown entity.

Small enhancements on datamodel.

Fixes #38 